### PR TITLE
fix: unsubscribe shortcuts when removed

### DIFF
--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -30,6 +30,21 @@ describe('Service: Hotkeys', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('should unsubscribe shortcuts when removed', () => {
+    const subscription = spectator.service.addShortcut({ keys: 'meta.a' }).subscribe();
+    spectator.service.removeShortcuts('meta.a');
+    expect(subscription.closed).toBe(true);
+  });
+
+  it('should delete hotkey and disposer when unsubscribed', () => {
+    spectator.service
+      .addShortcut({ keys: 'meta.a' })
+      .subscribe()
+      .unsubscribe();
+    expect(spectator.service.getHotkeys().length).toBe(0);
+    expect(spectator.service['disposers'].has('meta.a')).toBe(false);
+  });
+
   it('should listen to keydown', () => {
     const spyFcn = createSpy('subscribe', e => {});
     spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -25,9 +25,6 @@ describe('Service: Hotkeys', () => {
     spectator.service.removeShortcuts(['meta.a', 'meta.b']);
     spectator.service.removeShortcuts('meta.c');
     expect(spectator.service.getHotkeys().length).toBe(0);
-    const spy = spyOn(console, 'warn');
-    spectator.service.removeShortcuts('meta.c');
-    expect(spy).toHaveBeenCalled();
   });
 
   it('should unsubscribe shortcuts when removed', () => {
@@ -42,7 +39,6 @@ describe('Service: Hotkeys', () => {
       .subscribe()
       .unsubscribe();
     expect(spectator.service.getHotkeys().length).toBe(0);
-    expect(spectator.service['disposers'].has('meta.a')).toBe(false);
   });
 
   it('should listen to keydown', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

removeShortcuts() does not unsubscribe addShortcut()'s observable.

Issue Number: #30

## What is the new behavior?
When removeShortcuts() is called, it will unsubscribe the observable correspond to the removed hotkey.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

This PR will change the behavior of the existing API, but I don't think this breaks working applications.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
