### PR TITLE
fix: dispose EventManager when unsubscribed

### DIFF
--- a/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
@@ -102,6 +102,7 @@ export class HotkeysService {
 
       return () => {
         this.hotkeys.delete(normalizedKeys);
+        dispose();
       };
     }).pipe(takeUntil<KeyboardEvent>(this.dispose.pipe(filter(v => v === normalizedKeys))));
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
unsubscribing hotkeys does not dispose Angular's Eventmanager


Issue Number: N/A

## What is the new behavior?
unsubscribing hotkeys disposes Angular's Eventmanager

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In https://github.com/ngneat/hotkeys/pull/31 , I have mistakenly deleted this line: https://github.com/ngneat/hotkeys/pull/31/files#diff-5c61d3ce419d652be3efabb5f05fcda1bb59dc80fb447a4008a1852ce601ad79L103

This line should not be deleted because it is to dispose Angular's EventManager, not dispose hotkeys.
I'm sorry for making regressions.