### PR TITLE
fix: arrow keys mapping to keycodes

### DIFF
--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -136,6 +136,13 @@ describe('Service: Hotkeys', () => {
       ]
     });
   });
+
+  it('should listen to up', () => {
+    const spyFcn = createSpy('subscribe', e => {});
+    spectator.service.addShortcut({ keys: 'up' }).subscribe(spyFcn);
+    fakeKeyboardPress('ArrowUp');
+    expect(spyFcn).toHaveBeenCalled();
+  });
 });
 
 function fakeKeyboardPress(key: string, type = 'keydown') {

--- a/projects/ngneat/hotkeys/src/lib/utils/platform.ts
+++ b/projects/ngneat/hotkeys/src/lib/utils/platform.ts
@@ -6,14 +6,28 @@ export function hostPlatform(): Platform {
 }
 
 export function normalizeKeys(keys: string, platform: Platform): string {
-  const lowercaseKeys = keys.toLowerCase();
-  switch (platform) {
-    case 'pc':
-      return lowercaseKeys
-        .split('.')
-        .map(k => (k === 'meta' ? 'control' : k))
-        .join('.');
-    default:
-      return keys;
+  const transformMap = {
+    up: 'ArrowUp',
+    down: 'ArrowDown',
+    left: 'ArrowLeft',
+    right: 'ArrowRight'
+  };
+
+  function transform(key: string): string {
+    if (platform === 'pc' && key === 'meta') {
+      key = 'control';
+    }
+
+    if (key in transformMap) {
+      key = transformMap[key];
+    }
+
+    return key;
   }
+
+  return keys
+    .toLowerCase()
+    .split('.')
+    .map(transform)
+    .join('.');
 }


### PR DESCRIPTION
Mapping `up` was not working as the keycode is `ArrowUp` (see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values). 

I couldn't manage to run the tests, I think that something needs to big fixed within angular dependencies. 