### PR TITLE
feat: add contenteditable handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ interface Options {
   // The type of event (defaults to `keydown`)
   trigger: 'keydown' | 'keyup';
   // Allow input, textarea and select as key event sources (defaults to []).
-  // It can be 'INPUT', 'TEXTAREA' or 'SELECT'.
+  // It can be 'INPUT', 'TEXTAREA', 'SELECT' or 'CONTENTEDITABLE'.
   allowIn: AllowInElement[];
   // hotkey description
   description: string;
@@ -211,7 +211,7 @@ The pipe accepts and additional parameter the way key combinations are separated
 
 ## Allowing hotkeys in form elements
 
-By default, the library prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element. To enable hotkeys in these elements, specify them in the `allowIn` parameter:
+By default, the library prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element or any elements that are contenteditable. To enable hotkeys in these elements, specify them in the `allowIn` parameter:
 
 ```ts
 import { HotkeysService } from '@ngneat/hotkeys';
@@ -226,7 +226,7 @@ export class AppComponent {
 
   ngOnInit() {
     this.hotkeys
-      .addShortcut({ keys: 'meta.a', allowIn: ['INPUT', 'SELECT', 'TEXTAREA'] })
+      .addShortcut({ keys: 'meta.a', allowIn: ['INPUT', 'SELECT', 'TEXTAREA', 'CONTENTEDITABLE'] })
       .subscribe(e => console.log('Hotkey', e));
   }
 }
@@ -239,7 +239,7 @@ It's possible to enable them in the template as well:
 <input hotkeys="meta.n" 
       hotkeysGroup="File" 
       hotkeysDescription="New Document" 
-      hotkeysOptions="{allowIn: ['INPUT','SELECT', 'TEXTAREA']}" 
+      hotkeysOptions="{allowIn: ['INPUT','SELECT', 'TEXTAREA', 'CONTENTEDITABLE']}" 
       (hotkey)="handleHotkey($event)"
 ```
 

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
@@ -36,6 +36,30 @@ describe('Directive: Hotkeys', () => {
     expect(spyFcn).toHaveBeenCalled();
   });
 
+  it('should ignore hotkey when typing in a contentEditable element', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator = createDirective(`<div [hotkeys]="'a'"><div contenteditable="true"></div></div>`);
+    spectator.output('hotkey').subscribe(spyFcn);
+    spyOnProperty(document.activeElement, 'nodeName', 'get').and.returnValue('DIV');
+    spyOnProperty(document.activeElement as HTMLElement, 'isContentEditable', 'get').and.returnValue(true);
+    spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'a');
+    spectator.fixture.detectChanges();
+    expect(spyFcn).not.toHaveBeenCalled();
+  });
+
+  it('should trigger hotkey when typing in a contentEditable element', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator = createDirective(
+      `<div [hotkeys]="'a'" [hotkeysOptions]="{allowIn: ['CONTENTEDITABLE']}"><div contenteditable="true"></div></div>`
+    );
+    spectator.output('hotkey').subscribe(spyFcn);
+    spyOnProperty(document.activeElement, 'nodeName', 'get').and.returnValue('DIV');
+    spyOnProperty(document.activeElement as HTMLElement, 'isContentEditable', 'get').and.returnValue(true);
+    spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'a');
+    spectator.fixture.detectChanges();
+    expect(spyFcn).toHaveBeenCalled();
+  });
+
   it('should register hotkey', () => {
     spectator = createDirective(`<div [hotkeys]="'a'"></div>`);
     spectator.fixture.detectChanges();
@@ -143,6 +167,46 @@ describe('Directive: Sequence Hotkeys', () => {
       await sleep(250);
       spectator.fixture.detectChanges();
       expect(spyFcn).not.toHaveBeenCalled();
+    };
+
+    return run();
+  });
+
+  it('should ignore hotkey when typing in a contentEditable element', () => {
+    const run = async () => {
+      // * Need to space out time to prevent other test keystrokes from interfering with sequence
+      await sleep(250);
+      const spyFcn = createSpy('subscribe', (...args) => {});
+      spectator = createDirective(`<div [hotkeys]="'g>n'" [isSequence]="true"><div contenteditable="true"></div>`);
+      spectator.output('hotkey').subscribe(spyFcn);
+      spyOnProperty(document.activeElement, 'nodeName', 'get').and.returnValue('DIV');
+      spyOnProperty(document.activeElement as HTMLElement, 'isContentEditable', 'get').and.returnValue(true);
+      spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'g', spectator.element);
+      spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'n', spectator.element);
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).not.toHaveBeenCalled();
+    };
+
+    return run();
+  });
+
+  it('should trigger hotkey when typing in a contentEditable element', () => {
+    const run = async () => {
+      // * Need to space out time to prevent other test keystrokes from interfering with sequence
+      await sleep(250);
+      const spyFcn = createSpy('subscribe', (...args) => {});
+      spectator = createDirective(
+        `<div [hotkeys]="'g>n'" [isSequence]="true" [hotkeysOptions]="{allowIn: ['CONTENTEDITABLE']}"><div contenteditable="true"></div>`
+      );
+      spectator.output('hotkey').subscribe(spyFcn);
+      spyOnProperty(document.activeElement, 'nodeName', 'get').and.returnValue('DIV');
+      spyOnProperty(document.activeElement as HTMLElement, 'isContentEditable', 'get').and.returnValue(true);
+      spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'g', spectator.element);
+      spectator.dispatchKeyboardEvent(spectator.element.firstElementChild, 'keydown', 'n', spectator.element);
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).toHaveBeenCalled();
     };
 
     return run();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number #36: Contenteditable elements are not handled the same was as `input`, `textarea` or `select` elements.

## What is the new behavior?

Ignores events from contenteditable elements by default and adds a new `CONTENTEDITABLE` allowIn type.

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```

Events from contenteditable elements are ignored by default. The previous behaviour can be restored by adding  `CONTENTEDITABLE ` to `allowIn`.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

closes #36 