### PR TITLE
feat: add aliases to the hotkeys pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ The pipe accepts and additional parameter the way key combinations are separated
 </div>
 ```
 
+It is also possible to alias keys to custom strings. For example, the macos key for enter is `⌤`. To display it as `Enter`, you can use the following:
+
+```html
+<div class="help-dialog-shortcut-key">
+  <kbd [innerHTML]="hotkey.keys | hotkeysShortcut: '-' : ' then ': {enter: 'Enter'}"></kbd>
+</div>
+
+```html
+
 ## Allowing hotkeys in form elements
 
 By default, the library prevents hotkey callbacks from firing when their event originates from an `input`, `select`, or `textarea` element or any elements that are contenteditable. To enable hotkeys in these elements, specify them in the `allowIn` parameter:

--- a/projects/ngneat/hotkeys/src/lib/hotkeys-shortcut.pipe.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys-shortcut.pipe.ts
@@ -1,6 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 import { hostPlatform } from './utils/platform';
+import { CustomAliases } from './utils/alias';
 
 const symbols = {
   shift: '&#8679;',
@@ -38,7 +39,7 @@ export class HotkeysShortcutPipe implements PipeTransform {
     this.symbols = this.getPlatformSymbols(platform);
   }
 
-  transform(value: string, dotSeparator = ' + ', thenSeparator = ' then '): any {
+  transform(value: string, dotSeparator = ' + ', thenSeparator = ' then ', aliases: CustomAliases = {}): any {
     if (!value) {
       return '';
     }
@@ -48,7 +49,7 @@ export class HotkeysShortcutPipe implements PipeTransform {
         s
           .split('.')
           .map((c) => c.toLowerCase())
-          .map((c) => this.symbols[c] || c)
+          .map((c) => aliases[c] || this.symbols[c] || c)
           .join(dotSeparator),
       )
       .join(thenSeparator);

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys-shortcut.pipe.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys-shortcut.pipe.spec.ts
@@ -57,6 +57,14 @@ describe('Pipe: Hotkeys Shortcut', () => {
     const spectator = createPipe(`{{ 'shift.r' | hotkeysShortcut : '#'}}`);
     expect(spectator.element).toHaveText('&#8679;#r');
   }));
+
+  it('should format keys according to alias', fakeAsync(() => {
+    const spectator = createPipe(`{{ ' alt.enter.up' | hotkeysShortcut :' + ':' then ':{enter: 'enter', up: '^'} }}`);
+    expect(spectator.element).toHaveText('enter');
+    expect(spectator.element).toHaveText('^');
+    expect(spectator.element).not.toHaveText('⌤');
+    expect(spectator.element).not.toHaveText('↑');
+  }));
 });
 
 describe('Pipe: Sequence Hotkeys Shortcut', () => {
@@ -111,5 +119,13 @@ describe('Pipe: Sequence Hotkeys Shortcut', () => {
   it('should format hotkey with custom separator', fakeAsync(() => {
     const spectator = createPipe(`{{ 'shift.r>t' | hotkeysShortcut:'#':' > '}}`);
     expect(spectator.element).toHaveText('&#8679;#r > t');
+  }));
+
+  it('should format keys according to alias', fakeAsync(() => {
+    const spectator = createPipe(`{{ ' alt>enter>up.a' | hotkeysShortcut :' + ':' then ':{enter: 'enter', up: '^'} }}`);
+    expect(spectator.element).toHaveText('enter');
+    expect(spectator.element).toHaveText('^');
+    expect(spectator.element).not.toHaveText('⌤');
+    expect(spectator.element).not.toHaveText('↑');
   }));
 });

--- a/projects/ngneat/hotkeys/src/lib/utils/alias.ts
+++ b/projects/ngneat/hotkeys/src/lib/utils/alias.ts
@@ -1,0 +1,17 @@
+type ModifierKey =
+  | 'shift'
+  | 'control'
+  | 'alt'
+  | 'meta'
+  | 'altleft'
+  | 'backspace'
+  | 'tab'
+  | 'left'
+  | 'right'
+  | 'up'
+  | 'down'
+  | 'enter'
+  | 'space'
+  | 'escape';
+
+export type CustomAliases = { [key in ModifierKey]?: string };


### PR DESCRIPTION
Adds a parameter to the pipe accepting an object containing aliases for the modifier keys

closes #65

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The hotkeys pipe only replaces keys with predetermined hardcoded strings

Issue Number: N/A

## What is the new behavior?

The hotkeys pipe accepts an object with aliases for the main modifier keys and replaces those with the values from the object when applicable

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
