### PR TITLE
feat: adds a global modifier to the directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ Now you have two ways to start adding shortcuts to your application:
 
 > Hotkeys take care of transforming keys from macOS to Linux and Windows and vice-versa.
 
-Additionally, the directive accepts three more `input`s:
+Additionally, the directive accepts five more `input`s:
 
 - `hotkeysGroup` - define the group name.
 - `hotkeysDescription` - add a description.
 - `hotkeysOptions` - See [Options](#options)
 - `isSequence` - indicate hotkey is a sequence of keys.
+- `isGlobal` - the hotkey event fires even if the element is not focused or active
 
 For example:
 
@@ -95,7 +96,9 @@ For example:
 <input hotkeys="meta.n" 
       hotkeysGroup="File" 
       hotkeysDescription="New Document" 
-      (hotkey)="handleHotkey($event)"
+      (hotkey)="handleHotkey($event)"/>
+
+<button hotkeys="shift.f" isGlobal (hotkey)="handleHotkey($event)">Click me</button>
 ```
 
 Example sequence hotkey:

--- a/projects/ngneat/hotkeys/src/lib/hotkeys.directive.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys.directive.ts
@@ -28,7 +28,13 @@ export class HotkeysDirective implements OnChanges, OnDestroy {
   private subscription: Subscription;
 
   hotkeys = input<string>();
-  isSequence = input(false);
+  // allows the user to set the value by just adding the attribute to the element
+  isSequence = input(false, {
+    transform: (value: boolean | string) => (typeof value === 'string' ? value === '' || value === 'true' : value),
+  });
+  isGlobal = input(false, {
+    transform: (value: boolean | string) => (typeof value === 'string' ? value === '' || value === 'true' : value),
+  });
   hotkeysGroup = input<string>();
   hotkeysOptions = input<Partial<Options>>({});
   hotkeysDescription = input<string>();
@@ -38,6 +44,7 @@ export class HotkeysDirective implements OnChanges, OnDestroy {
     keys: this.hotkeys(),
     group: this.hotkeysGroup(),
     description: this.hotkeysDescription(),
+    global: this.isGlobal(),
     ...this.hotkeysOptions(),
   }));
 


### PR DESCRIPTION
Adds a prop to the directive that causes the listener to be set in the document element

closes #35

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The directive only fires the hotkey event when it's host element is active

Issue Number: #35

## What is the new behavior?

A new isGlobal prop in the directive causes the hotkey event to be fired whenever it's allowed

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
