### PR TITLE
feat: adds pausing and resuming to the hotkey service

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ this.hotkeys.removeShortcuts('meta.a');
 this.hotkeys.removeShortcuts(['meta.1', 'meta.2']);
 ```
 
+### `pauseShortcuts and resumeShortcuts`
+
+Pause the handling of all shortcuts. This is especially useful to prevent hotkeys from firing when a modal or sidebar is open.
+
+```ts
+// hotkey subscriptions won't emmit, and hotkeys callbacks won't be called
+this.hotkeys.pauseShortcuts();
+// hotkeys will work again
+this.hotkeys.resumeShortcuts();
+// get the current state of the hotkeys
+this.hotkeys.isPaused();
+```
+
 ### `setSequenceDebounce`
 
 Set the number of milliseconds to debounce a sequence of keys

--- a/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
@@ -55,9 +55,9 @@ export class HotkeysService {
   private sequenceMaps = new Map<HTMLElement, SequenceSummary>();
   private sequenceDebounce: number = 250;
 
-  private _isPaused = signal(false);
-  // readonly interface for the isPaused value
-  isPaused = computed(() => this._isPaused());
+  private _isActive = signal(true);
+  // readonly interface for the isActive value
+  isActive = computed(() => this._isActive());
 
   constructor(
     private eventManager: EventManager,
@@ -156,11 +156,9 @@ export class HotkeysService {
     return getSequenceCompleteObserver().pipe(
       takeUntil<Hotkey>(this.dispose.pipe(filter((v) => v === normalizedKeys))),
       filter((hotkey) => !this.targetIsExcluded(hotkey.allowIn)),
-      filter((hotkey) => !this._isPaused()),
+      filter((hotkey) => this._isActive()),
       tap((hotkey) => {
-        if (!this._isPaused()) {
-          this.callbacks.forEach((cb) => cb(hotkey, normalizedKeys, hotkey.element));
-        }
+        this.callbacks.forEach((cb) => cb(hotkey, normalizedKeys, hotkey.element));
       }),
       finalize(() => this.removeShortcuts(normalizedKeys)),
     );
@@ -191,7 +189,7 @@ export class HotkeysService {
           e.preventDefault();
         }
 
-        if (!this._isPaused()) {
+        if (this._isActive()) {
           this.callbacks.forEach((cb) => cb(e, normalizedKeys, hotkey.element));
           observer.next(e);
         }
@@ -208,7 +206,7 @@ export class HotkeysService {
         dispose();
       };
     }).pipe(
-      filter(() => !this._isPaused()),
+      filter(() => this._isActive()),
       takeUntil<KeyboardEvent>(this.dispose.pipe(filter((v) => v === normalizedKeys))),
     );
   }
@@ -278,11 +276,11 @@ export class HotkeysService {
     return isExcluded;
   }
 
-  pauseHotkeys() {
-    this._isPaused.set(true);
+  pause() {
+    this._isActive.set(false);
   }
 
-  resumeHotkeys() {
-    this._isPaused.set(false);
+  resume() {
+    this._isActive.set(true);
   }
 }

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
@@ -16,6 +16,38 @@ describe('Directive: Hotkeys', () => {
     spectator.fixture.detectChanges();
   });
 
+  it('should not trigger hotkey output if hotkeys are paused, should trigger again when resumed', () => {
+    spectator = createDirective(`<div [hotkeys]="'a'"></div>`);
+
+    const hotkeysService = spectator.inject(HotkeysService);
+    hotkeysService.pauseHotkeys();
+    const spyFcn = createSpy('subscribe', (e) => {});
+    spectator.output('hotkey').subscribe(spyFcn);
+    spectator.fixture.detectChanges();
+    spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'a');
+    expect(spyFcn).not.toHaveBeenCalled();
+
+    hotkeysService.resumeHotkeys();
+    spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'a');
+    expect(spyFcn).toHaveBeenCalled();
+  });
+
+  it('should not trigger global hotkey output if hotkeys are paused, should trigger again when resumed', () => {
+    spectator = createDirective(`<div [hotkeys]="'a'" isGlobal></div>`);
+
+    const hotkeysService = spectator.inject(HotkeysService);
+    hotkeysService.pauseHotkeys();
+    const spyFcn = createSpy('subscribe', (e) => {});
+    spectator.output('hotkey').subscribe(spyFcn);
+    spectator.fixture.detectChanges();
+    spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'a');
+    expect(spyFcn).not.toHaveBeenCalled();
+
+    hotkeysService.resumeHotkeys();
+    spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'a');
+    expect(spyFcn).toHaveBeenCalled();
+  });
+
   const shouldIgnoreOnInputTest = (directiveExtras?: string) => {
     const spyFcn = createSpy('subscribe', (...args) => {});
     spectator = createDirective(`<div [hotkeys]="'a'" ${directiveExtras ?? ''}><input></div>`);
@@ -164,6 +196,60 @@ describe('Directive: Sequence Hotkeys', () => {
       spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'm');
       await sleep(250);
       spectator.fixture.detectChanges();
+    };
+
+    return run();
+  });
+
+  it('should not trigger sequence hotkey if hotkeys are paused, should trigger again when resumed', () => {
+    const run = async () => {
+      // * Need to space out time to prevent other test keystrokes from interfering with sequence
+      await sleep(250);
+      const spyFcn = createSpy('subscribe', (...args) => {});
+      spectator = createDirective(`<div [hotkeys]="'g>m'" [isSequence]="true"></div>`);
+      const hotkeysService = spectator.inject(HotkeysService);
+
+      hotkeysService.pauseHotkeys();
+      spectator.output('hotkey').subscribe(spyFcn);
+      spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'g');
+      spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'm');
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).not.toHaveBeenCalled();
+
+      hotkeysService.resumeHotkeys();
+      spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'g');
+      spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'm');
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).toHaveBeenCalled();
+    };
+
+    return run();
+  });
+
+  it('should not trigger global sequence hotkey if hotkeys are paused, should trigger again when resumed', () => {
+    const run = async () => {
+      // * Need to space out time to prevent other test keystrokes from interfering with sequence
+      await sleep(250);
+      const spyFcn = createSpy('subscribe', (...args) => {});
+      spectator = createDirective(`<div [hotkeys]="'g>m'" [isSequence]="true" isGlobal></div>`);
+      const hotkeysService = spectator.inject(HotkeysService);
+
+      hotkeysService.pauseHotkeys();
+      spectator.output('hotkey').subscribe(spyFcn);
+      spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'g');
+      spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'm');
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).not.toHaveBeenCalled();
+
+      hotkeysService.resumeHotkeys();
+      spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'g');
+      spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'm');
+      await sleep(250);
+      spectator.fixture.detectChanges();
+      expect(spyFcn).toHaveBeenCalled();
     };
 
     return run();

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.directive.spec.ts
@@ -20,14 +20,14 @@ describe('Directive: Hotkeys', () => {
     spectator = createDirective(`<div [hotkeys]="'a'"></div>`);
 
     const hotkeysService = spectator.inject(HotkeysService);
-    hotkeysService.pauseHotkeys();
+    hotkeysService.pause();
     const spyFcn = createSpy('subscribe', (e) => {});
     spectator.output('hotkey').subscribe(spyFcn);
     spectator.fixture.detectChanges();
     spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'a');
     expect(spyFcn).not.toHaveBeenCalled();
 
-    hotkeysService.resumeHotkeys();
+    hotkeysService.resume();
     spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'a');
     expect(spyFcn).toHaveBeenCalled();
   });
@@ -36,14 +36,14 @@ describe('Directive: Hotkeys', () => {
     spectator = createDirective(`<div [hotkeys]="'a'" isGlobal></div>`);
 
     const hotkeysService = spectator.inject(HotkeysService);
-    hotkeysService.pauseHotkeys();
+    hotkeysService.pause();
     const spyFcn = createSpy('subscribe', (e) => {});
     spectator.output('hotkey').subscribe(spyFcn);
     spectator.fixture.detectChanges();
     spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'a');
     expect(spyFcn).not.toHaveBeenCalled();
 
-    hotkeysService.resumeHotkeys();
+    hotkeysService.resume();
     spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'a');
     expect(spyFcn).toHaveBeenCalled();
   });
@@ -209,7 +209,7 @@ describe('Directive: Sequence Hotkeys', () => {
       spectator = createDirective(`<div [hotkeys]="'g>m'" [isSequence]="true"></div>`);
       const hotkeysService = spectator.inject(HotkeysService);
 
-      hotkeysService.pauseHotkeys();
+      hotkeysService.pause();
       spectator.output('hotkey').subscribe(spyFcn);
       spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'g');
       spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'm');
@@ -217,7 +217,7 @@ describe('Directive: Sequence Hotkeys', () => {
       spectator.fixture.detectChanges();
       expect(spyFcn).not.toHaveBeenCalled();
 
-      hotkeysService.resumeHotkeys();
+      hotkeysService.resume();
       spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'g');
       spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'm');
       await sleep(250);
@@ -236,7 +236,7 @@ describe('Directive: Sequence Hotkeys', () => {
       spectator = createDirective(`<div [hotkeys]="'g>m'" [isSequence]="true" isGlobal></div>`);
       const hotkeysService = spectator.inject(HotkeysService);
 
-      hotkeysService.pauseHotkeys();
+      hotkeysService.pause();
       spectator.output('hotkey').subscribe(spyFcn);
       spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'g');
       spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'm');
@@ -244,7 +244,7 @@ describe('Directive: Sequence Hotkeys', () => {
       spectator.fixture.detectChanges();
       expect(spyFcn).not.toHaveBeenCalled();
 
-      hotkeysService.resumeHotkeys();
+      hotkeysService.resume();
       spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'g');
       spectator.dispatchKeyboardEvent(document.documentElement, 'keydown', 'm');
       await sleep(250);

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -48,10 +48,10 @@ describe('Service: Hotkeys', () => {
   it('should not listen to keydown if hotkeys are paused, should listen again when resumed', () => {
     const spyFcn = createSpy('subscribe', (e) => {});
     spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
-    spectator.service.pauseHotkeys();
+    spectator.service.pause();
     fakeKeyboardPress('a');
     expect(spyFcn).not.toHaveBeenCalled();
-    spectator.service.resumeHotkeys();
+    spectator.service.resume();
     fakeKeyboardPress('a');
     expect(spyFcn).toHaveBeenCalled();
   });
@@ -76,11 +76,11 @@ describe('Service: Hotkeys', () => {
     spectator.service.addShortcut({ keys: 'a' }).subscribe();
     spectator.service.onShortcut(spyFcn);
 
-    spectator.service.pauseHotkeys();
+    spectator.service.pause();
     fakeKeyboardPress('a');
     expect(spyFcn).not.toHaveBeenCalled();
 
-    spectator.service.resumeHotkeys();
+    spectator.service.resume();
     fakeKeyboardPress('a');
     expect(spyFcn).toHaveBeenCalled();
   });

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -45,6 +45,17 @@ describe('Service: Hotkeys', () => {
     expect(spyFcn).toHaveBeenCalled();
   });
 
+  it('should not listen to keydown if hotkeys are paused, should listen again when resumed', () => {
+    const spyFcn = createSpy('subscribe', (e) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.pauseHotkeys();
+    fakeKeyboardPress('a');
+    expect(spyFcn).not.toHaveBeenCalled();
+    spectator.service.resumeHotkeys();
+    fakeKeyboardPress('a');
+    expect(spyFcn).toHaveBeenCalled();
+  });
+
   it('should listen to keyup', () => {
     const spyFcn = createSpy('subscribe', (e) => {});
     spectator.service.addShortcut({ keys: 'a', trigger: 'keyup' }).subscribe(spyFcn);
@@ -56,6 +67,20 @@ describe('Service: Hotkeys', () => {
     const spyFcn = createSpy('subscribe', (...args) => {});
     spectator.service.addShortcut({ keys: 'a' }).subscribe();
     spectator.service.onShortcut(spyFcn);
+    fakeKeyboardPress('a');
+    expect(spyFcn).toHaveBeenCalled();
+  });
+
+  it('should not call callback when hotkeys are paused, should call again when resumed', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe();
+    spectator.service.onShortcut(spyFcn);
+
+    spectator.service.pauseHotkeys();
+    fakeKeyboardPress('a');
+    expect(spyFcn).not.toHaveBeenCalled();
+
+    spectator.service.resumeHotkeys();
     fakeKeyboardPress('a');
     expect(spyFcn).toHaveBeenCalled();
   });

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,14 @@
+.container {
+  padding: 2rem;
+  max-width: 400px;
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div #container>
+<div #container class="container">
   <input
     #input
     placeholder="meta.a"
@@ -27,4 +27,10 @@
     [hotkeysOptions]="{ allowIn: ['INPUT'] }"
     [isSequence]="true"
   />
+
+  <div class="grid-container">
+    <button (click)="pauseHotkeys()">pause hotkeys</button>
+    <button (click)="resumeHotkeys()">resume hotkeys</button>
+  </div>
+  <span> Hotkeys are {{ isPaused() ? 'paused' : 'active' }} </span>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,5 +32,5 @@
     <button (click)="pauseHotkeys()">pause hotkeys</button>
     <button (click)="resumeHotkeys()">resume hotkeys</button>
   </div>
-  <span> Hotkeys are {{ isPaused() ? 'paused' : 'active' }} </span>
+  <span> Hotkeys are {{ isActive() ? 'active' : 'paused' }} </span>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class AppComponent implements AfterViewInit {
   input2 = viewChild<ElementRef<HTMLElement>>('input2');
   input3 = viewChild<ElementRef<HTMLElement>>('input3');
   container = viewChild<ElementRef<HTMLElement>>('container');
-  isPaused = this.hotkeys.isPaused;
+  isActive = this.hotkeys.isActive;
 
   ngAfterViewInit(): void {
     this.hotkeys.onShortcut((event, keys) => console.log(keys));
@@ -104,10 +104,10 @@ export class AppComponent implements AfterViewInit {
   }
 
   pauseHotkeys() {
-    this.hotkeys.pauseHotkeys();
+    this.hotkeys.pause();
   }
 
   resumeHotkeys() {
-    this.hotkeys.resumeHotkeys();
+    this.hotkeys.resume();
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ export class AppComponent implements AfterViewInit {
   input2 = viewChild<ElementRef<HTMLElement>>('input2');
   input3 = viewChild<ElementRef<HTMLElement>>('input3');
   container = viewChild<ElementRef<HTMLElement>>('container');
+  isPaused = this.hotkeys.isPaused;
 
   ngAfterViewInit(): void {
     this.hotkeys.onShortcut((event, keys) => console.log(keys));
@@ -100,5 +101,13 @@ export class AppComponent implements AfterViewInit {
 
   handleHotkey(e: KeyboardEvent) {
     console.log('New document hotkey', e);
+  }
+
+  pauseHotkeys() {
+    this.hotkeys.pauseHotkeys();
+  }
+
+  resumeHotkeys() {
+    this.hotkeys.resumeHotkeys();
   }
 }


### PR DESCRIPTION
adds a mechanism to pause and resume the hotkeys event, callbacks and subscription emissions

closes #62

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no way to pause the handling of hotkeys

Issue Number: #62

The hotkeys can be paused and resumed from the service

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
