### PR TITLE
fix: prevents duplicated shortcut's callback immediate execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ That's all for now! Make sure to check out the `playground` inside the `src` [fo
 
 No. It's not possible to define a hotkey multiple times. Each hotkey has a description and a group, so it doesn't make sense assigning a hotkey to different actions.
 
+In case of registering duplicated hotkeys, the `addShortcut` and `addSequenceShortcut` methods return an `EMPTY` observable, allowing to detect duplicated hotkeys registration and execute custom logic.
+
 **Why am I not receiving any event?**
 
 If you've added a hotkey to a particular element of your DOM, make sure it's focusable. Otherwise, hotkeys cannot capture any keyboard event.

--- a/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
@@ -137,7 +137,7 @@ export class HotkeysService {
 
         if (sequenceSummary.hotkeyMap.has(normalizedKeys)) {
           console.error('Duplicated shortcut');
-          return of(null);
+          return EMPTY;
         }
 
         sequenceSummary.hotkeyMap.set(normalizedKeys, hotkeySummary);
@@ -170,7 +170,7 @@ export class HotkeysService {
 
     if (this.hotkeys.has(normalizedKeys)) {
       console.error('Duplicated shortcut');
-      return of(null);
+      return EMPTY;
     }
 
     this.hotkeys.set(normalizedKeys, mergedOptions);

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -27,6 +27,30 @@ describe('Service: Hotkeys', () => {
     expect(spectator.service.getHotkeys().length).toBe(0);
   });
 
+  it('should not emit after registering duplicated shortcuts', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+
+    expect(spyFcn).not.toHaveBeenCalled();
+  });
+
+  it('should emit once per event matching shortcut even if duplicated shortcuts registration was attempted', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+
+    fakeKeyboardPress('a');
+    expect(spyFcn).toHaveBeenCalledTimes(1);
+
+    fakeBodyKeyboardSequencePress(['g', 'a']);
+    expect(spyFcn).toHaveBeenCalledTimes(1);
+  });
+
   it('should unsubscribe shortcuts when removed', () => {
     const subscription = spectator.service.addShortcut({ keys: 'meta.a' }).subscribe();
     spectator.service.removeShortcuts('meta.a');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)x
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Current behavior: when registering a duplicated shortcut, the observable returned by the duplicate shortcut registration immediately emits `null` on subscribe, resulting in the shortcut's callback being executed immediately even though the shortcut wasn't triggered.

Issue Number: 72

## What is the new behavior?

The observable returned by the duplicated shortcut's registration is EMPTY, it never emits and completes immediately. This fixes the issue.

## Does this PR introduce a breaking change?

```
[x] Yes
[] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If a consumer relies on the observable emitting `null` to detect duplicate shortcuts and trigger custom logic, then this change is breaking.
It can be mitigated though: since rxjs `EMPTY` is a constant, one can check equality of the value returned by `addShortcut` and `addSequenceShortcut` to detect duplicated shortcuts:

```js
  const shortcutObs = this.hotkeysService.addShortcut({ keys: 'control.c' });
  if (shortcutObs === EMPTY) {
     // custom logic for duplicate shortcut
  }
```

## Other information

closes https://github.com/ngneat/hotkeys/issues/72