### PR TITLE
fix: prevents duplicated shortcut's callback immediate execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ That's all for now! Make sure to check out the `playground` inside the `src` [fo
 
 No. It's not possible to define a hotkey multiple times. Each hotkey has a description and a group, so it doesn't make sense assigning a hotkey to different actions.
 
+In case of registering duplicated hotkeys, the `addShortcut` and `addSequenceShortcut` methods return an `EMPTY` observable, allowing to detect duplicated hotkeys registration and execute custom logic.
+
 **Why am I not receiving any event?**
 
 If you've added a hotkey to a particular element of your DOM, make sure it's focusable. Otherwise, hotkeys cannot capture any keyboard event.

--- a/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
+++ b/projects/ngneat/hotkeys/src/lib/hotkeys.service.ts
@@ -137,7 +137,7 @@ export class HotkeysService {
 
         if (sequenceSummary.hotkeyMap.has(normalizedKeys)) {
           console.error('Duplicated shortcut');
-          return of(null);
+          return EMPTY;
         }
 
         sequenceSummary.hotkeyMap.set(normalizedKeys, hotkeySummary);
@@ -170,7 +170,7 @@ export class HotkeysService {
 
     if (this.hotkeys.has(normalizedKeys)) {
       console.error('Duplicated shortcut');
-      return of(null);
+      return EMPTY;
     }
 
     this.hotkeys.set(normalizedKeys, mergedOptions);

--- a/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
+++ b/projects/ngneat/hotkeys/src/lib/tests/hotkeys.service.spec.ts
@@ -27,6 +27,30 @@ describe('Service: Hotkeys', () => {
     expect(spectator.service.getHotkeys().length).toBe(0);
   });
 
+  it('should not emit after registering duplicated shortcuts', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+
+    expect(spyFcn).not.toHaveBeenCalled();
+  });
+
+  it('should emit once per event matching shortcut even if duplicated shortcuts registration was attempted', () => {
+    const spyFcn = createSpy('subscribe', (...args) => {});
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addShortcut({ keys: 'a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+    spectator.service.addSequenceShortcut({ keys: 'g>a' }).subscribe(spyFcn);
+
+    fakeKeyboardPress('a');
+    expect(spyFcn).toHaveBeenCalledTimes(1);
+
+    fakeBodyKeyboardSequencePress(['g', 'a']);
+    expect(spyFcn).toHaveBeenCalledTimes(1);
+  });
+
   it('should unsubscribe shortcuts when removed', () => {
     const subscription = spectator.service.addShortcut({ keys: 'meta.a' }).subscribe();
     spectator.service.removeShortcuts('meta.a');


### PR DESCRIPTION
Updated the cache according to https://github.com/ngneat/hotkeys/pull/98#issuecomment-2729762446